### PR TITLE
Minify files and use specific gulp-usemin version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,8 @@
   var bump = require("gulp-bump");
   var jshint = require("gulp-jshint");
   var rename = require("gulp-rename");
+  var minifyCSS = require("gulp-minify-css");
+  var sourcemaps = require("gulp-sourcemaps");
   var uglify = require('gulp-uglify');
   var usemin = require("gulp-usemin");
   var colors = require("colors");
@@ -14,7 +16,6 @@
 
   var appJSFiles = [
     "src/js/**/*.js",
-    "src/index.html",
     "!./src/components/**/*"
   ];
 
@@ -28,7 +29,6 @@
 
   gulp.task("lint", function() {
     return gulp.src(appJSFiles)
-      .pipe(jshint.extract("auto"))
       .pipe(jshint())
       .pipe(jshint.reporter("jshint-stylish"))
       .pipe(jshint.reporter("fail"));
@@ -57,7 +57,10 @@
 
   gulp.task("source", ["lint"], function () {
     return gulp.src(['./src/index.html'])
-      .pipe(usemin({}))
+      .pipe(usemin({
+        css: [sourcemaps.init(), minifyCSS(), sourcemaps.write()],
+        js: [sourcemaps.init(), uglify(), sourcemaps.write()]
+      }))
       .pipe(gulp.dest("dist/"));
   });
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "gulp-rename": "~1.2.0",
     "gulp-uglify": "~1.2.0",
     "gulp-jshint": "~1.10.0",
-    "gulp-usemin": "~0.3.9",
+    "gulp-minify-css": "^1.2.1",
+    "gulp-sourcemaps": "^1.5.2",
+    "gulp-usemin": "0.3.11",
     "jshint-stylish": "~1.0.2",
     "run-sequence": "~1.1.0"
   }

--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,7 @@
   <script src="components/webcomponentsjs/webcomponents-lite.min.js"></script>
   <link rel="import" href="components/rise-google-calendar/rise-google-calendar.html">
 
-  <!-- build:css css/style.css -->
+  <!-- build:css css/style.min.css -->
   <link rel="stylesheet" href="css/style.css">
   <!-- endbuild -->
 
@@ -41,7 +41,7 @@
 </head>
 <body>
 
-  
+
   <rise-google-calendar
     calendar-id="cameroncodes.com_l0vl6b8laf08tb39lv2vegd1qg@group.calendar.google.com"
     refresh="5">
@@ -95,7 +95,7 @@
 
   </div> <!-- .wrapper -->
 
-  <!-- build:js js/events.js -->
+  <!-- build:js js/events.min.js -->
   <script type="text/javascript" src="components/moment/moment.js"></script>
   <script type="text/javascript" src="js/theme-events.js"></script>
   <script type="text/javascript" src="js/common.js"></script>


### PR DESCRIPTION
- gulp-usemin has issues in latest versions and even last release, specifying `0.3.11` which works
- minifying JS and CSS
